### PR TITLE
DEV-2750 Deserialize the occurred at timestamp

### DIFF
--- a/cloudevents/events.py
+++ b/cloudevents/events.py
@@ -36,7 +36,7 @@ class CEMessageMode(str, Enum):
     """Enum: CEMessageMode
 
     In CloudEvents, two message modes exist:
-    - BINARY        : event-attributes are seperated from the payload
+    - BINARY        : event-attributes are separated from the payload
     - STRUCTURED    : event-attributes are included in the payload, the payload
                       itself is moved to the `data`-field.
     """

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,19 @@
+from datetime import datetime, timezone, timedelta
+
+from cloudevents.events import EventAttributes
+
+
+class TestEventAttributes:
+    def test_init_time(self):
+        attrs = EventAttributes()
+        assert attrs.time is not None
+        assert type(attrs.time) is datetime
+        assert attrs.time < datetime.now(timezone.utc)
+
+        attrs2 = EventAttributes(time="wrong")
+        assert attrs2.time is None
+
+        attrs3 = EventAttributes(time="2025-08-19 13:05:11.892067+02:00")
+        assert attrs3.time == datetime(
+            2025, 8, 19, 13, 5, 11, 892067, tzinfo=timezone(timedelta(seconds=7200))
+        )


### PR DESCRIPTION
The timestamp indicating the occurrence of the event is serialized as an ISO 8601 formatted string in the attributes. This value was not deserialized though, resulting in every deserialized event having the default timestamp, which is the time at deserialization.