### PR TITLE
DEV-2752 Fix event time as int

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,14 @@
 .PHONY: pre-condition
 pre-condition:
 ifndef VIRTUAL_ENV
-	@echo "Python virtual environment not activated. Exiting..."
+	@echo 'Python virtual environment not activated. Activate with `source .venv/bin/activate`.'
+	@echo 'Exiting...'
 	exit 1
 endif
 
 .PHONY: dev-install
 dev-install: pre-condition
-	python -m pip install .
+	python -m pip install -e .
 	python -m pip install '.[dev]'
 
 .PHONY: check-format

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ source .venv/bin/activate
 3. Install the library (editable) and the dev/test dependencies:
 
 ```bash
-(.venv) python -m pip install .
+(.venv) python -m pip install -e .
 (.venv) python -m pip install '.[dev]'
 ```
 

--- a/src/cloudevents/events.py
+++ b/src/cloudevents/events.py
@@ -89,7 +89,7 @@ class EventAttributes:
 
     # See: https://docs.python.org/3/library/time.html#time.time_ns (3.7+)
     def get_event_time_as_int(self) -> int:
-        epoch = datetime.datetime.utcfromtimestamp(0)
+        epoch = datetime.fromtimestamp(0, self.time.tzinfo)
         return round((self.time - epoch).total_seconds() * 1000.0)
 
     def _parse_time(self, time: Optional[str]) -> Optional[datetime]:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,19 +1,39 @@
 from datetime import datetime, timezone, timedelta
 
-from cloudevents.events import EventAttributes
+from src.cloudevents.events import EventAttributes
 
 
 class TestEventAttributes:
     def test_init_time(self):
+        # Default timestamp
         attrs = EventAttributes()
         assert attrs.time is not None
         assert type(attrs.time) is datetime
+        assert attrs.time.tzinfo == timezone.utc
         assert attrs.time < datetime.now(timezone.utc)
 
         attrs2 = EventAttributes(time="wrong")
         assert attrs2.time is None
 
+        # Timezone-aware
         attrs3 = EventAttributes(time="2025-08-19 13:05:11.892067+02:00")
         assert attrs3.time == datetime(
             2025, 8, 19, 13, 5, 11, 892067, tzinfo=timezone(timedelta(seconds=7200))
         )
+
+        # Timezone-naive
+        attrs4 = EventAttributes(time="2025-08-19 13:05:11.892067")
+        assert attrs4.time == datetime(2025, 8, 19, 13, 5, 11, 892067)
+
+    def test_get_event_time_as_int(self):
+        # Timezone-aware
+        attrs = EventAttributes(time="2025-08-19 13:05:11.892067+02:00")
+        assert attrs.get_event_time_as_int() == 1755601511892
+
+        # Timezone-naive
+        attrs_2 = EventAttributes(time="2025-08-19 13:05:11.892067")
+        assert attrs_2.get_event_time_as_int() == 1755605111892
+
+        # Default timestamp
+        attrs_3 = EventAttributes()
+        assert attrs_3.get_event_time_as_int() > 1755601511892

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone, timedelta
 
-from src.cloudevents.events import EventAttributes
+from cloudevents.events import EventAttributes
 
 
 class TestEventAttributes:


### PR DESCRIPTION
There was an issue with the refactor. The class "datetime" is imported instead of the module but the code was not adapted properly.

Also, the occurred-at timestamp is a timezone-aware timestamp. The epoch timestamp (datetime.utcfromtimestamp()) however is timezone-naive. It is not possible to subtract a naive timestamp from an aware one: "TypeError: can't subtract offset-naive and offset-aware datetimes". Changed the epoch timestamp so that it reuses (!) the tzinfo from the occurred-at timestamp. The epoch timestamp can be timezone-aware or timestamp-naive, depending one occurred-at timestamp.

Finally, the test imported from the bytecode file (.pyc) and not the actual source code (.py). Fixed the import to point to the source code.